### PR TITLE
add package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/jkrup/docker-dev-tools.git"
+  },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "chalk": "^2.4.2",


### PR DESCRIPTION
see https://docs.npmjs.com/files/package.json\#repository

This should make the gh link show up in npm, and also allow users to type `npm repo docker-dev-tools` and have it open the GH repo in their browser.

PS: cool talk! looking forward to checking it out!